### PR TITLE
Fix empty initializations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   * client.consumptions.by_aggregates() replaces client.consumptions_by_aggregates()
 * Consumptions arguments are now passed as body data instead of GET params
 * Fixed BUG at API init (asserting URL) #16
-* Fixed BUG at install process race condition
+* Fixed BUG at install process race condition #17
+* Inits can be performed with None user as a deactivated okW client instances #19
 
 ## 0.2.0 - First productive client!
 * Package renamed to "orakwlum_client"

--- a/orakwlum_client/orakwlum_api.py
+++ b/orakwlum_client/orakwlum_api.py
@@ -72,10 +72,14 @@ class orakWlum_API(object):
 
         return AVAILABLE_METHODS[method](resource, headers=headers, **kwargs)
 
+
     def login(self):
         """
         Authenticate current client, trying to reach a valid access token.
         """
+        if not self.activated:
+            return False
+
         login_data = {
             "email": self.user,
             "password": self.password,
@@ -87,12 +91,16 @@ class orakWlum_API(object):
         if ("error" not in result or not result['error']) and "token" in result:
             self.token = result['token']
 
+
     def method(self, method, resource, **kwargs):
         """
         Main method handler
 
         So far, ask the API and return a JSON representation of the response
         """
+        if not self.activated:
+            return False
+
         try:
             result = self.API(method=method, resource=resource, **kwargs)
         except:
@@ -100,6 +108,7 @@ class orakWlum_API(object):
             result = self.API(method=method, resource=resource, **kwargs)
 
         return result.json()
+
 
     def get(self, resource, **kwargs):
         """

--- a/orakwlum_client/orakwlum_api.py
+++ b/orakwlum_client/orakwlum_api.py
@@ -11,15 +11,26 @@ CURRENT_API = "v1"
 
 class orakWlum_API(object):
     def __init__(self, url, user, password):
-        assert type(url) == str and len(url) > 0 and url.startswith("http"), "Provided URL '{}' is not correct, it must be a string with an URI".format(url)
-        assert type(user) == str and len(user) > 0, "Provided user '{}' is not correct, it must be a string".format(user)
-        assert type(password) == str and len(password) > 0, "Provided password '{}' is not correct, it must be a string.".format(password)
+        if user is not None:
+            assert type(url) == str and len(url) > 0 and url.startswith("http"), "Provided URL '{}' is not correct, it must be a string with an URI".format(url)
+            assert type(user) == str and len(user) > 0, "Provided user '{}' is not correct, it must be a string".format(user)
+            assert type(password) == str and len(password) > 0, "Provided password '{}' is not correct, it must be a string.".format(password)
 
-        self.url = url + "/api/{CURRENT_API}".format(CURRENT_API=CURRENT_API)
-        self.token = None
+            self.url = url + "/api/{CURRENT_API}".format(CURRENT_API=CURRENT_API)
+            self.token = None
 
-        self.user = user
-        self.password = password
+            self.user = user
+            self.password = password
+
+            self.activated = True
+
+        else:
+            self.activated = False
+            self.user = None
+            self.password = None
+            self.token = None
+            self.url = None
+
 
     def API(self, **kwargs):
         """


### PR DESCRIPTION
It fixes empty initializations marking the instance as not activated and enforcing that all available methods do not nothing (just as a protection).

This will not raise just for None configured user. If user is not right (incorrect  format, ...) will still raising and trying to activate the client instance.

Fix #19 Handle empty inits