### PR TITLE
Fix specs cassetes reutilization

### DIFF
--- a/specs/fixtures/okW_Client/consumptions.yaml
+++ b/specs/fixtures/okW_Client/consumptions.yaml
@@ -1,5 +1,23 @@
 interactions:
 - request:
+    body: '{"email": "test@gisce.net", "password": "test@gisce.net"}'
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['57']
+      Content-Type: [application/json]
+      User-Agent: [python-requests/2.18.4]
+    method: POST
+    uri: http://localhost:5000/api/v1/get_token
+  response:
+    body: {string: "{\n  \"token\": \"eyJhbGciOiJIUzI1NiIsImlhdCI6MTUxMTI1NTI2MSwiZXhwIjoxNTEyNDY0ODYxfQ.eyJlbWFpbCI6InRlc3RAZ2lzY2UubmV0IiwiZ3JvdXBzIjpbIlVzZXIiXSwicm9sZXMiOiJVc2VyIiwiaW1hZ2UiOiJpbWFnZXMvdXNlci5qcGcifQ.RCczxGkCbcTCcsmTCHoCAIxjVND6EGTLeOPkzpm1oIU\"\n}\n"}
+    headers:
+      Content-Length: ['243']
+      Content-Type: [application/json]
+    status: {code: 200, message: OK}
+
+- request:
     body: null
     headers:
       Accept: ['*/*']

--- a/specs/fixtures/okW_Client/consumptions.yaml
+++ b/specs/fixtures/okW_Client/consumptions.yaml
@@ -26,7 +26,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.18.4]
     method: GET
-    uri: http://localhost:5000/api/v1/consumptions?date_start=1472688000&date_end=1475280000&cups=ES0000000000000000AA
+    uri: http://localhost:5000/api/v1/consumptions
   response:
     body: {string: "{\n  \"result\": {\n    \"ES0000000000000000AA\": {\n      \"consumption\":
         10.0, \n      \"total\": 10.0\n    }\n  }\n}\n"}

--- a/specs/orakwlum_api_spec.py
+++ b/specs/orakwlum_api_spec.py
@@ -18,7 +18,7 @@ expected = {
 fixtures_path = 'specs/fixtures/okW_API/'
 
 spec_VCR = vcr.VCR(
-    record_mode='new_episodes',
+    record_mode='none',
     cassette_library_dir=fixtures_path
 )
 

--- a/specs/orakwlum_client_spec.py
+++ b/specs/orakwlum_client_spec.py
@@ -51,7 +51,7 @@ consumption_expected = {
 fixtures_path = 'specs/fixtures/okW_Client/'
 
 spec_VCR = vcr.VCR(
-    record_mode='new_episodes',
+    record_mode='none',
     cassette_library_dir=fixtures_path
 )
 


### PR DESCRIPTION
It fixes specs cassetes reutilization to validate that the Client works with simulated API responses.

Fix #21 